### PR TITLE
android & sdk version update, changelog

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * Fix for eventName emitting "message" most of the time
 * Org endpoints changed to product id
 * Password reset url changed to match url used in iOS.
+* Workaround/fix for sign up not throwing exception on error.
 
 
 0.4.1

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+0.4.2
+=====
+* Support for all device types/names by platform id
+* Global listener in ParticleCloud for system events
+* resetFlashingState - works with global system events instead of flashing timer
+* Fix for eventName emitting "message" most of the time
+* Org endpoints changed to product id
+* Password reset url changed to match url used in iOS.
+
+
 0.4.1
 =====
 * Optional account information included in sign up api calls

--- a/cloudsdk/build.gradle
+++ b/cloudsdk/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'me.tatarka.retrolambda'
 
 // This is the library version used when deploying the artifact
-version = '0.4.1'
+version = '0.4.2'
 
 ext {
     bintrayRepo = 'android'
@@ -71,7 +71,7 @@ dependencies {
     compile 'com.squareup.retrofit:retrofit:1.9.0'
     compile 'org.greenrobot:eventbus:3.0.0'
 
-    compile 'com.android.support:support-fragment:25.3.0'
+    compile 'com.android.support:support-fragment:25.3.1'
 
     retrolambdaConfig 'net.orfjackal.retrolambda:retrolambda:2.3.0'
 }

--- a/cloudsdk/src/main/java/io/particle/android/sdk/cloud/ApiDefs.java
+++ b/cloudsdk/src/main/java/io/particle/android/sdk/cloud/ApiDefs.java
@@ -121,7 +121,6 @@ public class ApiDefs {
         @POST("/v1/users")
         Response signUp(@Body SignUpInfo signUpInfo);
 
-
         // NOTE: the `LogInResponse` used here as a return type is intentional.  It looks
         // a little odd, but that's how this endpoint works.
         @POST("/v1/products/{productId}/customers")

--- a/example_app/build.gradle
+++ b/example_app/build.gradle
@@ -41,8 +41,8 @@ dependencies {
     // UNCOMMENT THE FOLLOWING TO USE A PUBLISHED VERSION OF THE SDK:
     //    compile 'io.particle:cloudsdk:0.3.3'
 
-    compile 'com.android.support:appcompat-v7:25.3.0'
-    compile 'com.android.support:support-fragment:25.3.0'
+    compile 'com.android.support:appcompat-v7:25.3.1'
+    compile 'com.android.support:support-fragment:25.3.1'
 
     retrolambdaConfig 'net.orfjackal.retrolambda:retrolambda:2.3.0'
 }


### PR DESCRIPTION
CloudSdk Release 0.4.2
* Support for all device types/names by platform id
* Global listener in ParticleCloud for system events
* resetFlashingState - works with global system events instead of flashing timer
* Fix for eventName emitting "message" most of the time
* Org endpoints changed to product id
* Password reset url changed to match url used in iOS.